### PR TITLE
Extended docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ web:
     ADMIN_PASSWORD: 'password'
     BASE_URI: 'https://demo.com/'
     IMPORT_GITHUB_PUB_KEYS: 'your-github-user-name'
-    DB_HOST: db
-    DB_DATABASE: 'neos-db'
-    DB_USER: 'neos-user'
-    DB_PASS: 'password'
 db:
   image: mariadb:latest
   expose:
@@ -63,8 +59,8 @@ db:
   volumes:
     - /data
   environment:
-    MYSQL_DATABASE: 'neos-db'
-    MYSQL_USER: 'neos-user'
-    MYSQL_PASSWORD: 'password'
+    MYSQL_DATABASE: 'db'
+    MYSQL_USER: 'admin'
+    MYSQL_PASSWORD: 'pass'
     MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ web:
     ADMIN_PASSWORD: 'password'
     BASE_URI: 'https://demo.com/'
     IMPORT_GITHUB_PUB_KEYS: 'your-github-user-name'
+    DB_HOST: db
+    DB_DATABASE: 'neos-db'
+    DB_USER: 'neos-user'
+    DB_PASS: 'password'
 db:
   image: mariadb:latest
   expose:
@@ -59,5 +63,8 @@ db:
   volumes:
     - /data
   environment:
-    MARIADB_PASS: pass
+    MYSQL_DATABASE: 'neos-db'
+    MYSQL_USER: 'neos-user'
+    MYSQL_PASSWORD: 'password'
+    MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
 ```


### PR DESCRIPTION
I'm not sure if I'm doing something wrong, but I think you have to specify `MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, MYSQL_RANDOM_ROOT_PASSWORD` instead of `MARIADB_PASS` as an env var. Maybe the example relies on the [tutum/mariadb](https://github.com/tutumcloud/mariadb) image which is no longer maintained.