### PR TITLE
BUGFIX: Added VERSION option

### DIFF
--- a/root/etc/cont-init.d/10-init-neos
+++ b/root/etc/cont-init.d/10-init-neos
@@ -6,6 +6,7 @@ DB_HOST=${DB_HOST:="db"}
 DB_USER=${DB_USER:="admin"}
 DB_PASS=${DB_PASS:="pass"}
 REPOSITORY_URL=${REPOSITORY_URL:=""}
+VERSION=${VERSION:="master"}
 BASE_URI=${BASE_URI:=${BASE_URI:=""}}
 
 # Provision conainer at first run
@@ -54,7 +55,7 @@ else
 	# Needed to serve as a deployment target
 	###
 	cd /data/transfer
-	git clone $REPOSITORY_URL .
+	git clone -b $VERSION $REPOSITORY_URL .
 	composer install
 
 	rsync -a /data/transfer/ /data/releases/current/


### PR DESCRIPTION
I'm again not realy sure, but I think the VERSION option (using a different GIT branch) isn't implemented. I added the -b $VERSION argument to the git clone command.