### PR TITLE
BUGFIX: Add a then statement

### DIFF
--- a/root/etc/cont-init.d/10-init-neos
+++ b/root/etc/cont-init.d/10-init-neos
@@ -65,7 +65,8 @@ if [[ $RESULT -gt 0 ]];
 		fi
 
 		if [ -z "$DONT_PUBLISH_PERSISTENT" ]
-			./flow resource:publish
+			then
+				./flow resource:publish
 		fi
 fi
 


### PR DESCRIPTION
I got this error message, after running `docker-compose up`:
```
web_1  | /var/run/s6/etc/cont-init.d/10-init-neos: line 69: syntax error near unexpected token `fi'                                                                                           
web_1  | [cont-init.d] 10-init-neos: exited 2.
```
